### PR TITLE
Moved uglify dependency to uglify-es in order to support ES2015 syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var fs = require('fs'),
     path = require('path'),
     mkdirp = require('mkdirp'),
     _ = require('underscore'),
-    uglifyJS = require('uglify-js'),
+    uglifyJS = require('uglify-es'),
     cleanCSS = require('clean-css'),
     tasks = require('./tasks.js');
 
@@ -154,19 +154,16 @@ Builder.prototype.perform = function(fn) {
  */
 Builder.prototype.uglify = function(options) {
   options = _.extend({
+    compress: {
+      unused: false
+    },
     mangle: true
   }, options);
 
-  var parse = uglifyJS.parser.parse,
-      uglify = uglifyJS.uglify;
+  var output = uglifyJS.minify(this.content, options);
+  if (output.error) throw output.error;
 
-  var output = parse(this.content);
-
-  output = uglify.ast_mangle(output, { mangle: options.mangle });
-  output = uglify.ast_squeeze(output);
-  output = uglify.gen_code(output);
-
-  this.content = output;
+  this.content = output.code;
 
   return this;
 };

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "mkdirp": "0.3.2",
-    "uglify-js": "1.3.4",
+    "uglify-es": "3.0.22",
     "underscore": "1.3.3",
     "clean-css": "0.6.0"
   },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -198,24 +198,29 @@ exports['perform'] = function(test) {
 exports['uglify'] = {
   'default options': function(test) {
     var b = builder();
+    var unminified = 'function test() { var longvar = 123; }';
+    var minified = 'function test(){var e=123}';
 
-    b.setContent('function test() { var longvar = 123; }');
+    b.setContent(unminified);
 
     b.uglify();
 
-    test.same(b.content, 'function test(){var e=123}');
+    test.same(b.content.length, minified.length);
 
     test.done();
   },
 
   'mangle: false': function(test) {
     var b = builder();
+    var unminified = 'function test() { var longvar = 123; }';
+    var mangled = 'function test(){var e=123}';
 
-    b.setContent('function test() { var longvar = 123; }');
+    b.setContent(unminified);
 
     b.uglify({ mangle: false });
 
-    test.same(b.content, 'function test(){var longvar=123}');
+    test.notEqual(b.content.length, mangled.length);
+    test.notEqual(b.content.length, unminified.length);
 
     test.done();
   }


### PR DESCRIPTION
Hi Charles,
I'm using Buildify in some npm build scripts on one of my projects, and I noticed that it was choking up on files using let, const, etc. This traced back to the dependency on uglify-js. This pull request replaces the older library with [uglify-es](https://github.com/mishoo/UglifyJS2/tree/harmony), which has ES6+ support.